### PR TITLE
fix TVA to allow for variable idomain

### DIFF
--- a/src/Utilities/UtlTva.f90
+++ b/src/Utilities/UtlTva.f90
@@ -298,7 +298,7 @@ contains
     end do
 
     ! copy values from this object into the passed array
-    do nr = 1, this%isize
+    do nr = 1, this%dis%nodes
       nu = this%dis%get_nodeuser(nr)
       dblvec(nr) = this%variables(ivar)%dblvec(nu)
     end do


### PR DESCRIPTION
TVA was not properly copying from a user sized input array (for saltwater head) into the swi%hsalt.